### PR TITLE
update js to allow extending base class, as well as allowing $validator to be passed to parent

### DIFF
--- a/js/recaptcha.js
+++ b/js/recaptcha.js
@@ -1,5 +1,5 @@
 window.addEventListener("load",function() {
-    document.getElementById('RecaptchaForm_'+'$formName').addEventListener('submit', function (event) {
+    document.getElementById('$formName').addEventListener('submit', function (event) {
         event.preventDefault();    //stop form from submitting
         var submittedForm = event.target;
         // needs for recaptacha ready

--- a/src/Form/RecaptchaField.php
+++ b/src/Form/RecaptchaField.php
@@ -63,7 +63,7 @@ class RecaptchaField extends FormField
             "siteKey" => $this->getSiteKey(),
             "customFunction" => $this->customFunction,
             "customNameFunction" => $this->customFunctionName,
-            "formName" => $this->getForm()->name
+            "formName" => $this->getForm()->FormName()
         ];
 
         $recaptchaJs = 'https://www.google.com/recaptcha/api.js?render='.$this->getSiteKey();

--- a/src/Form/RecaptchaForm.php
+++ b/src/Form/RecaptchaForm.php
@@ -17,7 +17,8 @@ class RecaptchaForm extends Form
             $controller,
             $name,
             $formFields,
-            $formActions
+            $formActions,
+            $validator
         );
     }
 }


### PR DESCRIPTION
- fix to allow classes that extend the base RecaptchaForm to still work
- allow $validator to be passed to form __construct